### PR TITLE
Make list of temporary directory env vars checked match what Python uses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "talon-rpc",
     "displayName": "Talon RPC",
-    "version": "2.1.2",
+    "version": "2.2.0",
     "description": "RPC library for Talon",
     "author": "Andreas Arvidsson",
     "publisher": "AndreasArvidsson",

--- a/src/nodeIo/NodeIo.ts
+++ b/src/nodeIo/NodeIo.ts
@@ -14,8 +14,8 @@ export class NodeIo implements Io {
     private readonly responsePath: string;
     private responseFile: FileHandle | null;
 
-    constructor(dirName: string) {
-        this.dirPath = getCommunicationDirPath(dirName);
+    constructor(dirName: string, tmpDir?: string) {
+        this.dirPath = getCommunicationDirPath(dirName, tmpDir);
         this.signalsDir = join(this.dirPath, "signals");
         this.requestPath = join(this.dirPath, "request.json");
         this.responsePath = join(this.dirPath, "response.json");

--- a/src/nodeIo/getCommunicationDirPath.ts
+++ b/src/nodeIo/getCommunicationDirPath.ts
@@ -1,12 +1,16 @@
-import { tmpdir, userInfo } from "node:os";
-import { join } from "node:path";
+import * as os from "node:os";
+import * as path from "node:path";
 
-export function getCommunicationDirPath(name: string): string {
-    const info = userInfo();
+export function getCommunicationDirPath(name: string, tmpDir?: string): string {
+    const info = os.userInfo();
 
     // NB: On Windows, uid < 0, and the tmpdir is user-specific, so we don't
     // bother with a suffix
     const suffix = info.uid >= 0 ? `-${info.uid}` : "";
 
-    return join(tmpdir(), `${name}${suffix}`);
+    // Include TMPDIR to match the implementation of Pythons
+    // `tempfile.gettempdir()` that we use client side.
+    const tmpDirPath = tmpDir || process.env.TMPDIR || os.tmpdir();
+
+    return path.join(tmpDirPath, `${name}${suffix}`);
 }

--- a/src/nodeIo/getCommunicationDirPath.ts
+++ b/src/nodeIo/getCommunicationDirPath.ts
@@ -8,9 +8,10 @@ export function getCommunicationDirPath(name: string, tmpDir?: string): string {
     // bother with a suffix
     const suffix = info.uid >= 0 ? `-${info.uid}` : "";
 
-    // Include TMPDIR to match the implementation of Pythons
+    // Include TMPDIR, TEMP, and TMP to match the implementation of Pythons
     // `tempfile.gettempdir()` that we use client side.
-    const tmpDirPath = tmpDir || process.env.TMPDIR || os.tmpdir();
+    const tmpDirPath =
+        tmpDir || process.env.TMPDIR || process.env.TEMP || process.env.TMP || os.tmpdir();
 
     return path.join(tmpDirPath, `${name}${suffix}`);
 }

--- a/src/nodeIo/getCommunicationDirPath.ts
+++ b/src/nodeIo/getCommunicationDirPath.ts
@@ -8,7 +8,7 @@ export function getCommunicationDirPath(name: string, tmpDir?: string): string {
     // bother with a suffix
     const suffix = info.uid >= 0 ? `-${info.uid}` : "";
 
-    // Include TMPDIR, TEMP, and TMP to match the implementation of Pythons
+    // Include TMPDIR, TEMP, and TMP to match the implementation of Python's
     // `tempfile.gettempdir()` that we use client side.
     const tmpDirPath =
         tmpDir || process.env.TMPDIR || process.env.TEMP || process.env.TMP || os.tmpdir();


### PR DESCRIPTION
1. Check the environment variable TMPDIR, TEMP, and TMP to match the python client side implementation
2. Add optional argument to specified the temp dir so we can introduce a vscode setting override. This isn't used yet but we need to add it here before making a change on the extension side.